### PR TITLE
feat: add /neupan_waypoints to set the initial path

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ Subscribe Topics
 | Topic Name      | Message Type                | Description                                                                                        |
 | --------------- | --------------------------- | -------------------------------------------------------------------------------------------------- |
 | `/scan`         | `sensor_msgs/LaserScan`     | The laser scan data.                                                                               |
-| `/initial_path` | `nav_msgs/Path`             | The initial path for NeuPAN.                                                                       |
-| `/neupan_goal`  | `geometry_msgs/PoseStamped` | The goal for NeuPAN. You can publish the goal to this topic to give the NeuPAN planner a new goal. |
+| `/initial_path` | `nav_msgs/Path`             | Set the initial path directly for NeuPAN.                                                                   |
+| `/neupan_goal`  | `geometry_msgs/PoseStamped` | Set the goal for NeuPAN, the initial path will be generated from the current robot state to this goal point. |
+| `/neupan_waypoints`    | `nav_msgs/Path`             | Set the waypoints for NeuPAN, the initial path will be generated from the current robot state to these waypoints. |
+
+> [!NOTE]
+> To set (refresh) the initial path, you can use one of the above three topics: "initial_path", "neupan_goal" or "neupan_waypoints". Please set `refresh_initial_path` to `True` if you want to update the initial path continuously.
 
 ROS Parameters
 
@@ -66,7 +70,7 @@ ROS Parameters
 | `~scan_downsample`      | `int` / `1`          | The downsample rate of the laser scan.                   |
 | `~scan_range`           | `str` / `0.0, 5.0`   | The distance range of the laser scan.                    |
 | `~dune_checkpoint`      | `str` / `None`       | The path of the DUNE checkpoint file.                    |
-| `~refresh_initial_path` | `bool` / `False`     | Whether to refresh the initial path.                     |
+| `~refresh_initial_path` | `bool` / `False`     | Whether to refresh the initial path so that the planner can update the initial path from goal, waypoints or given path.                     |
 | `~flip_angle`           | `bool` / `False`     | Whether to flip the angle of the scan data.              |
 | `~include_initial_path_direction` | `bool` / `False`     | Whether to set the initial path direction from the given path. If `False`, the points gradient will be used as the initial path direction.            |
 

--- a/example/gazebo_limo/launch/neupan_gazebo_limo.launch
+++ b/example/gazebo_limo/launch/neupan_gazebo_limo.launch
@@ -10,6 +10,7 @@
     <arg name="marker_z" default='0.3'/>
     <arg name="scan_downsample" default='6'/>
     <arg name="dune_checkpoint" default='$(find neupan_ros)/example/gazebo_limo/pretrain_limo/model_5000.pth'/>
+    <arg name="refresh_initial_path" default='false'/>
 
     <node name='neupan_control' pkg="neupan_ros" type="neupan_node.py" output="screen">
         <param name="config_file" value="$(arg config_file)"/>
@@ -21,6 +22,7 @@
         <param name="marker_size" value="$(arg marker_size)"/>
         <param name="scan_downsample" value="$(arg scan_downsample)"/>
         <param name="dune_checkpoint" value="$(arg dune_checkpoint)"/>
+        <param name="refresh_initial_path" value="$(arg refresh_initial_path)"/>
         <remap from="/scan" to="/limo/scan"/>
         <remap from="/neupan_cmd_vel" to="/cmd_vel"/>
         <remap from="/neupan_goal" to="/move_base_simple/goal"/>


### PR DESCRIPTION
This PR adds a new `/neupan_waypoints` topic option to update Neupan’s initial path.